### PR TITLE
 Fix override error in BaremetalConditionVariable by renaming wait to pend

### DIFF
--- a/fprime-baremetal/Os/Baremetal/ConditionVariable.cpp
+++ b/fprime-baremetal/Os/Baremetal/ConditionVariable.cpp
@@ -8,7 +8,7 @@
 namespace Os {
 namespace Baremetal {
 
-void BaremetalConditionVariable::wait(Os::Mutex& mutex) {}
+ConditionVariableInterface::Status BaremetalConditionVariable::pend(Os::Mutex& mutex) {}
 void BaremetalConditionVariable::notify() {}
 void BaremetalConditionVariable::notifyAll() {}
 

--- a/fprime-baremetal/Os/Baremetal/ConditionVariable.hpp
+++ b/fprime-baremetal/Os/Baremetal/ConditionVariable.hpp
@@ -26,8 +26,8 @@ class BaremetalConditionVariable : public ConditionVariableInterface {
     //! \brief assignment operator is forbidden
     ConditionVariableInterface& operator=(const ConditionVariableInterface& other) override = delete;
 
-    //! \brief wait releasing mutex
-    void wait(Os::Mutex& mutex) override;
+    //! \brief pend releasing mutex
+    Status pend(Os::Mutex& mutex) override;
 
     //! \brief notify a single waiter
     void notify() override;


### PR DESCRIPTION
# Fix override error in `BaremetalConditionVariable` by renaming `wait` to `pend`

## Description  
This PR resolves a compilation error in `BaremetalConditionVariable` caused by the `wait` method being marked as `override` without actually overriding a base class method.  

## Changes  
- Renamed `wait(Os::Mutex&)` to `pend(Os::Mutex&)` in `ConditionVariable.hpp` and `ConditionVariable.cpp` to correctly match the expected interface.  
- Updated the method signature to properly override `ConditionVariableInterface::pend`.  

## Fixes  
- Resolves the following error:  
  ```cpp
  /fprime-baremetal/Os/Baremetal/ConditionVariable.hpp:30:10: error: 'void Os::Baremetal::BaremetalConditionVariable::wait(Os::Mutex&)' marked 'override', but does not override
  30 |     void wait(Os::Mutex& mutex) override;
  |          ^~~~
