### PR TITLE
Add TaskRunner.runAll method

### DIFF
--- a/fprime-baremetal/Os/TaskRunner/TaskRunner.cpp
+++ b/fprime-baremetal/Os/TaskRunner/TaskRunner.cpp
@@ -83,42 +83,48 @@ void TaskRunner::runOne(Task& task) {
     baremetal_handle.m_routine(baremetal_handle.m_argument);
 }
 
+bool TaskRunner::runNext() {
+    Task* task = this->m_task_table[this->m_index];
+    // Run a single task
+    if (task != nullptr && isRunning(*task)) {
+        this->runOne(*task);
+        // Check and remove exited task
+        if (task->getState() == Os::Task::State::EXITED) {
+            this->removeTask(task);
+        }
+        // Otherwise bump the next start task
+        else {
+            this->m_index = (this->m_index + 1) % Os::Baremetal::TASK_CAPACITY;
+        }
+        return true;
+    }
+    this->m_index = (this->m_index + 1) % Os::Baremetal::TASK_CAPACITY;
+    return false;
+}
+
 void TaskRunner::run() {
     // While cycling run a task and increment to the next
     if (this->m_cycling) {
         // Start at the next task
         for (FwSizeType i = 0; i < Os::Baremetal::TASK_CAPACITY; i++) {
-            Task* task = this->m_task_table[this->m_index];
-            // Run a single task
-            if (task != nullptr && isRunning(*task)) {
-                this->runOne(*task);
-                // Check and remove exited task
-                if (task->getState() == Os::Task::State::EXITED) {
-                    this->removeTask(task);
-                }
-                // Otherwise bump the next start task
-                else {
-                    this->m_index = (this->m_index + 1) % Os::Baremetal::TASK_CAPACITY;
-                }
+            // Run only one task.
+            if (runNext()) {
                 break;
             }
-            this->m_index = (this->m_index + 1) % Os::Baremetal::TASK_CAPACITY;
         }
     }
 }
 
 void TaskRunner::runAll() {
     if (this->m_cycling) {
+        this->m_index = 0;
         for (FwSizeType i = 0; i < Os::Baremetal::TASK_CAPACITY; i++) {
-            Task* task = this->m_task_table[i];
-            // Run a single task
-            if (task != nullptr && isRunning(*task)) {
-                this->runOne(*task);
-                // FIXME: Task exits are not supported when using runAll().
-                FW_ASSERT(task->getState() != Os::Task::State::EXITED);
+            // Run each task exactly once.
+            (void) runNext();
+            if (this->m_index == 0) {
+                break;
             }
         }
-        this->m_index = 0;
     }
 }
 }  // End namespace Baremetal

--- a/fprime-baremetal/Os/TaskRunner/TaskRunner.cpp
+++ b/fprime-baremetal/Os/TaskRunner/TaskRunner.cpp
@@ -106,5 +106,20 @@ void TaskRunner::run() {
         }
     }
 }
+
+void TaskRunner::runAll() {
+    if (this->m_cycling) {
+        for (FwSizeType i = 0; i < Os::Baremetal::TASK_CAPACITY; i++) {
+            Task* task = this->m_task_table[i];
+            // Run a single task
+            if (task != nullptr && isRunning(*task)) {
+                this->runOne(*task);
+                // FIXME: Task exits are not supported when using runAll().
+                FW_ASSERT(task->getState() != Os::Task::State::EXITED);
+            }
+        }
+        this->m_index = 0;
+    }
+}
 }  // End namespace Baremetal
 }  // End Namespace Os

--- a/fprime-baremetal/Os/TaskRunner/TaskRunner.hpp
+++ b/fprime-baremetal/Os/TaskRunner/TaskRunner.hpp
@@ -75,7 +75,8 @@ class TaskRunner : TaskRegistry {
     static TaskRunner& getSingleton();
   private:
     //! \brief helper to run a single unit of work, from this task
-    void runOne(Task& task);
+    static void runOne(Task& task);
+    bool runNext();
     Task* m_task_table[TASK_CAPACITY]; //!< Task table of registered tasks
     FwSizeType m_index = 0; //!< Index of current task
     bool m_cycling = true; //!< Is the task runner cycling

--- a/fprime-baremetal/Os/TaskRunner/TaskRunner.hpp
+++ b/fprime-baremetal/Os/TaskRunner/TaskRunner.hpp
@@ -68,6 +68,9 @@ class TaskRunner : TaskRegistry {
     //! ```
     void run();
 
+    //! \brief run each ready-to-run task once
+    void runAll();
+
     //! \brief get a singleton instance of the global task runner
     static TaskRunner& getSingleton();
   private:


### PR DESCRIPTION
This is useful on platforms that need to integrate task execution with other rategroup behaviors.

Future work: support letting tasks exit. (Not needed for my use case.)