### PR TITLE
Fix TlmLinearChan unit tests

### DIFF
--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
@@ -73,7 +73,7 @@ void Tester::runMultiChannel() {
     // do a run, and all the packets should be sent
     this->doRun(true);
     ASSERT_TRUE(this->m_bufferRecv);
-    ASSERT_EQ((FW_NUM_ARRAY_ELEMENTS(ID_0) / CHANS_PER_COMBUFFER) + 1, this->m_numBuffs);
+    ASSERT_EQ((FW_NUM_ARRAY_ELEMENTS(ID_0) + CHANS_PER_COMBUFFER - 1) / CHANS_PER_COMBUFFER, this->m_numBuffs);
 
     // verify packets
     for (NATIVE_UINT_TYPE n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_0); n++) {
@@ -97,7 +97,7 @@ void Tester::runMultiChannel() {
     // do a run, and all the packets should be sent
     this->doRun(true);
     ASSERT_TRUE(this->m_bufferRecv);
-    ASSERT_EQ((FW_NUM_ARRAY_ELEMENTS(ID_1) / CHANS_PER_COMBUFFER) + 1, this->m_numBuffs);
+    ASSERT_EQ((FW_NUM_ARRAY_ELEMENTS(ID_1) + CHANS_PER_COMBUFFER - 1) / CHANS_PER_COMBUFFER, this->m_numBuffs);
     
     // verify packets
     for (NATIVE_UINT_TYPE n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_1); n++) {

--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.hpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.hpp
@@ -7,8 +7,8 @@
 #ifndef TESTER_HPP
 #define TESTER_HPP
 
-#include "GTestBase.hpp"
-#include "Svc/TlmLinearChan/TlmLinearChan.hpp"
+#include "TlmLinearChanGTestBase.hpp"
+#include "fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.hpp"
 
 namespace Baremetal {
 


### PR DESCRIPTION
1. Broken includes, which broke after a change to the test autocode generation.
2. Incorrect rounding for test calculation, which broke after a change to the default value of FW_COM_BUFFER_MAX_SIZE.