### PR TITLE
Update types for compatibility with latest F Prime

### DIFF
--- a/fprime-baremetal/Svc/FatalHandler/FatalHandler.cpp
+++ b/fprime-baremetal/Svc/FatalHandler/FatalHandler.cpp
@@ -27,7 +27,7 @@ FatalHandler ::~FatalHandler() {}
 // Handler implementations for user-defined typed input ports
 // ----------------------------------------------------------------------
 
-void FatalHandler::FatalReceive_handler(const NATIVE_INT_TYPE portNum, FwEventIdType Id) {
+void FatalHandler::FatalReceive_handler(FwIndexType portNum, FwEventIdType Id) {
     // for **nix, delay then exit with error code
     Fw::Logger::log("FATAL %" PRI_FwEventIdType "handled.\n", Id);
     while (true) {}  // Returning might be bad

--- a/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.cpp
@@ -13,7 +13,7 @@ namespace Baremetal {
 
 TlmLinearChan::TlmLinearChan(const char* name) : TlmLinearChanComponentBase(name) {
     // clear buckets
-    for (NATIVE_UINT_TYPE entry = 0; entry < TLMCHAN_HASH_BUCKETS; entry++) {
+    for (U32 entry = 0; entry < TLMCHAN_HASH_BUCKETS; entry++) {
         this->m_tlmEntries[entry].updated = false;
         this->m_tlmEntries[entry].id = 0;
         this->m_tlmEntries[entry].used = false;
@@ -22,21 +22,21 @@ TlmLinearChan::TlmLinearChan(const char* name) : TlmLinearChanComponentBase(name
 
 TlmLinearChan::~TlmLinearChan() {}
 
-void TlmLinearChan::init(NATIVE_INT_TYPE queueDepth, /*!< The queue depth*/
-                   NATIVE_INT_TYPE instance    /*!< The instance number*/
+void TlmLinearChan::init(FwSizeType queueDepth, /*!< The queue depth*/
+                         FwEnumStoreType instance    /*!< The instance number*/
 ) {
     TlmLinearChanComponentBase::init(queueDepth, instance);
 }
 
-void TlmLinearChan::pingIn_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+void TlmLinearChan::pingIn_handler(const FwIndexType portNum, U32 key) {
     // return key
     this->pingOut_out(0, key);
 }
 
-void TlmLinearChan::TlmGet_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
+void TlmLinearChan::TlmGet_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
     // Compute index for entry
 
-    NATIVE_UINT_TYPE entry;
+    U32 entry;
     for (entry = 0; entry < TLMCHAN_HASH_BUCKETS; entry++) {
         if (this->m_tlmEntries[entry].id == id) {  // If bucket exists, check id
             break;
@@ -53,10 +53,10 @@ void TlmLinearChan::TlmGet_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw:
     }
 }
 
-void TlmLinearChan::TlmRecv_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
+void TlmLinearChan::TlmRecv_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val) {
     // Compute index for entry
 
-    NATIVE_UINT_TYPE entry;
+    U32 entry;
     for (entry = 0; entry < TLMCHAN_HASH_BUCKETS; entry++) {
         if (this->m_tlmEntries[entry].id == id || this->m_tlmEntries[entry].used == false) {  
             break;
@@ -72,7 +72,7 @@ void TlmLinearChan::TlmRecv_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw
     this->m_tlmEntries[entry].buffer = val;
 }
 
-void TlmLinearChan::Run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE context) {
+void TlmLinearChan::Run_handler(FwIndexType portNum, U32 context) {
     // Only write packets if connected
     if (not this->isConnected_PktSend_OutputPort(0)) {
         return;
@@ -98,12 +98,12 @@ void TlmLinearChan::Run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE contex
                 Fw::SerializeStatus stat = pkt.addValue(p_entry.id, p_entry.lastUpdate, p_entry.buffer);
                 // if this doesn't work, that means packet isn't big enough for
                 // even one channel, so assert
-                FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<NATIVE_INT_TYPE>(stat));
+                FW_ASSERT(Fw::FW_SERIALIZE_OK == stat, static_cast<FwAssertArgType>(stat));
             } else if (Fw::FW_SERIALIZE_OK == stat) {
                 // if there was still room, do nothing move on to the next channel in the packet
             } else  // any other status is an assert, since it shouldn't happen
             {
-                FW_ASSERT(0, static_cast<NATIVE_INT_TYPE>(stat));
+                FW_ASSERT(0, static_cast<FwAssertArgType>(stat));
             }
         }
     }

--- a/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.hpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.hpp
@@ -17,19 +17,19 @@ class TlmLinearChan : public TlmLinearChanComponentBase {
   public:
     TlmLinearChan(const char* compName);
     virtual ~TlmLinearChan();
-    void init(NATIVE_INT_TYPE queueDepth, /*!< The queue depth*/
-              NATIVE_INT_TYPE instance    /*!< The instance number*/
+    void init(FwSizeType queueDepth, /*!< The queue depth*/
+              FwEnumStoreType instance    /*!< The instance number*/
     );
 
   PRIVATE:
     // Port functions
-    void TlmRecv_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
-    void TlmGet_handler(NATIVE_INT_TYPE portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
-    void Run_handler(NATIVE_INT_TYPE portNum, NATIVE_UINT_TYPE context);
+    void TlmRecv_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
+    void TlmGet_handler(FwIndexType portNum, FwChanIdType id, Fw::Time& timeTag, Fw::TlmBuffer& val);
+    void Run_handler(FwIndexType portNum, U32 context);
     //! Handler implementation for pingIn
     //!
-    void pingIn_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
-                        U32 key                        /*!< Value to return to pinger*/
+    void pingIn_handler(const FwIndexType portNum, /*!< The port number*/
+                        U32 key                    /*!< Value to return to pinger*/
     );
 
     typedef struct tlmEntry {

--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
@@ -11,8 +11,8 @@
 #define MAX_HISTORY_SIZE 10
 #define QUEUE_DEPTH 10
 
-static const NATIVE_UINT_TYPE TEST_CHAN_SIZE = sizeof(FwChanIdType) + Fw::Time::SERIALIZED_SIZE + sizeof(U32);
-static const NATIVE_UINT_TYPE CHANS_PER_COMBUFFER =
+static const FwSizeType TEST_CHAN_SIZE = sizeof(FwChanIdType) + Fw::Time::SERIALIZED_SIZE + sizeof(U32);
+static const FwIndexType CHANS_PER_COMBUFFER =
     (FW_COM_BUFFER_MAX_SIZE - sizeof(FwPacketDescriptorType)) / TEST_CHAN_SIZE;
 
 namespace Baremetal {
@@ -66,7 +66,7 @@ void Tester::runMultiChannel() {
 
     this->clearBuffs();
     // send all updates
-    for (NATIVE_UINT_TYPE n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_0); n++) {
+    for (U32 n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_0); n++) {
         this->sendBuff(ID_0[n], n);
     }
 
@@ -76,7 +76,7 @@ void Tester::runMultiChannel() {
     ASSERT_EQ((FW_NUM_ARRAY_ELEMENTS(ID_0) / CHANS_PER_COMBUFFER) + 1, this->m_numBuffs);
 
     // verify packets
-    for (NATIVE_UINT_TYPE n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_0); n++) {
+    for (U32 n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_0); n++) {
         // printf("#: %d\n",n);
         this->checkBuff(n, FW_NUM_ARRAY_ELEMENTS(ID_0), ID_0[n], n);
     }
@@ -90,7 +90,7 @@ void Tester::runMultiChannel() {
 
     this->clearBuffs();
     // send all updates
-    for (NATIVE_UINT_TYPE n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_1); n++) {
+    for (U32 n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_1); n++) {
         this->sendBuff(ID_1[n], n);
     }
 
@@ -100,7 +100,7 @@ void Tester::runMultiChannel() {
     ASSERT_EQ((FW_NUM_ARRAY_ELEMENTS(ID_1) / CHANS_PER_COMBUFFER) + 1, this->m_numBuffs);
     
     // verify packets
-    for (NATIVE_UINT_TYPE n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_1); n++) {
+    for (U32 n = 0; n < FW_NUM_ARRAY_ELEMENTS(ID_1); n++) {
         // printf("#: %d\n",n);
         this->checkBuff(n, FW_NUM_ARRAY_ELEMENTS(ID_1), ID_1[n], n);
     }
@@ -127,14 +127,14 @@ void Tester::runOffNominal() {
 // Handlers for typed from ports
 // ----------------------------------------------------------------------
 
-void Tester ::from_PktSend_handler(const NATIVE_INT_TYPE portNum, Fw::ComBuffer& data, U32 context) {
+void Tester ::from_PktSend_handler(const FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
     this->pushFromPortEntry_PktSend(data, context);
     this->m_bufferRecv = true;
     this->m_rcvdBuffer[this->m_numBuffs] = data;
     this->m_numBuffs++;
 }
 
-void Tester ::from_pingOut_handler(const NATIVE_INT_TYPE portNum, U32 key) {
+void Tester ::from_pingOut_handler(const FwIndexType portNum, U32 key) {
     this->pushFromPortEntry_pingOut(key);
 }
 
@@ -154,7 +154,7 @@ bool Tester::doRun(bool check) {
     return this->m_bufferRecv;
 }
 
-void Tester::checkBuff(NATIVE_UINT_TYPE chanNum, NATIVE_UINT_TYPE totalChan, FwChanIdType id, U32 val) {
+void Tester::checkBuff(FwIndexType chanNum, FwIndexType totalChan, FwChanIdType id, U32 val) {
     Fw::Time timeTag;
     // deserialize packet
     Fw::SerializeStatus stat;
@@ -166,10 +166,10 @@ void Tester::checkBuff(NATIVE_UINT_TYPE chanNum, NATIVE_UINT_TYPE totalChan, FwC
         tlc004 = true;
     }
 
-    NATIVE_UINT_TYPE currentChan = 0;
+    FwIndexType currentChan = 0;
 
     // Search for channel ID
-    for (NATIVE_UINT_TYPE packet = 0; packet < this->m_numBuffs; packet++) {
+    for (FwIndexType packet = 0; packet < this->m_numBuffs; packet++) {
         // Look at packet descriptor for current packet
         this->m_rcvdBuffer[packet].resetDeser();
         // first piece should be tlm packet descriptor
@@ -178,7 +178,7 @@ void Tester::checkBuff(NATIVE_UINT_TYPE chanNum, NATIVE_UINT_TYPE totalChan, FwC
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
         ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_TELEM));
 
-        for (NATIVE_UINT_TYPE chan = 0; chan < CHANS_PER_COMBUFFER; chan++) {
+        for (FwIndexType chan = 0; chan < CHANS_PER_COMBUFFER; chan++) {
             // decode channel ID
             FwEventIdType sentId;
             stat = this->m_rcvdBuffer[packet].deserialize(sentId);
@@ -249,7 +249,7 @@ void Tester::sendBuff(FwChanIdType id, U32 val) {
 
 void Tester::clearBuffs() {
     this->m_numBuffs = 0;
-    for (NATIVE_INT_TYPE n = 0; n < TLMCHAN_HASH_BUCKETS; n++) {
+    for (U32 n = 0; n < TLMCHAN_HASH_BUCKETS; n++) {
         this->m_rcvdBuffer[n].resetSer();
     }
 }

--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
@@ -12,7 +12,7 @@
 #define QUEUE_DEPTH 10
 
 static const FwSizeType TEST_CHAN_SIZE = sizeof(FwChanIdType) + Fw::Time::SERIALIZED_SIZE + sizeof(U32);
-static const FwIndexType CHANS_PER_COMBUFFER =
+static const FwChanIdType CHANS_PER_COMBUFFER =
     (FW_COM_BUFFER_MAX_SIZE - sizeof(FwPacketDescriptorType)) / TEST_CHAN_SIZE;
 
 namespace Baremetal {
@@ -154,7 +154,7 @@ bool Tester::doRun(bool check) {
     return this->m_bufferRecv;
 }
 
-void Tester::checkBuff(FwIndexType chanNum, FwIndexType totalChan, FwChanIdType id, U32 val) {
+void Tester::checkBuff(FwChanIdType chanNum, FwChanIdType totalChan, FwChanIdType id, U32 val) {
     Fw::Time timeTag;
     // deserialize packet
     Fw::SerializeStatus stat;
@@ -166,7 +166,7 @@ void Tester::checkBuff(FwIndexType chanNum, FwIndexType totalChan, FwChanIdType 
         tlc004 = true;
     }
 
-    FwIndexType currentChan = 0;
+    FwChanIdType currentChan = 0;
 
     // Search for channel ID
     for (FwIndexType packet = 0; packet < this->m_numBuffs; packet++) {
@@ -178,7 +178,7 @@ void Tester::checkBuff(FwIndexType chanNum, FwIndexType totalChan, FwChanIdType 
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
         ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_TELEM));
 
-        for (FwIndexType chan = 0; chan < CHANS_PER_COMBUFFER; chan++) {
+        for (FwChanIdType chan = 0; chan < CHANS_PER_COMBUFFER; chan++) {
             // decode channel ID
             FwEventIdType sentId;
             stat = this->m_rcvdBuffer[packet].deserialize(sentId);

--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.hpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.hpp
@@ -42,7 +42,7 @@ class Tester : public TlmLinearChanGTestBase {
 
     //! Handler for from_PktSend
     //!
-    void from_PktSend_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_PktSend_handler(FwIndexType portNum, /*!< The port number*/
                               Fw::ComBuffer& data,           /*!<
                                     Buffer containing packet data
                                     */
@@ -53,7 +53,7 @@ class Tester : public TlmLinearChanGTestBase {
 
     //! Handler for from_pingOut
     //!
-    void from_pingOut_handler(const NATIVE_INT_TYPE portNum, /*!< The port number*/
+    void from_pingOut_handler(FwIndexType portNum, /*!< The port number*/
                               U32 key                        /*!<
                                                  Value to return to pinger
                                                  */
@@ -74,7 +74,7 @@ class Tester : public TlmLinearChanGTestBase {
 
     void sendBuff(FwChanIdType id, U32 val);
     bool doRun(bool check);
-    void checkBuff(NATIVE_UINT_TYPE chanNum, NATIVE_UINT_TYPE totalChan, FwChanIdType id, U32 val);
+    void checkBuff(FwIndexType chanNum, FwIndexType totalChan, FwChanIdType id, U32 val);
 
     void clearBuffs();
 
@@ -90,7 +90,7 @@ class Tester : public TlmLinearChanGTestBase {
     //!
     TlmLinearChan component;
     // Keep a history
-    NATIVE_UINT_TYPE m_numBuffs;
+    FwIndexType m_numBuffs;
     Fw::ComBuffer m_rcvdBuffer[TLMCHAN_HASH_BUCKETS];
     bool m_bufferRecv;
 };

--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.hpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.hpp
@@ -74,7 +74,7 @@ class Tester : public TlmLinearChanGTestBase {
 
     void sendBuff(FwChanIdType id, U32 val);
     bool doRun(bool check);
-    void checkBuff(FwIndexType chanNum, FwIndexType totalChan, FwChanIdType id, U32 val);
+    void checkBuff(FwChanIdType chanNum, FwChanIdType totalChan, FwChanIdType id, U32 val);
 
     void clearBuffs();
 


### PR DESCRIPTION
`fprime-baremetal` uses types that no longer exist in the latest `devel` version of F Prime. This PR helps update these types and makes `fprime-baremetal` compile again with F Prime commit `aad0e6e0d789cfcf35e846b292e3a0eae273a1df`.