### PR TITLE
Update MicroFS cmake to use new API

### DIFF
--- a/fprime-baremetal/Os/Baremetal/CMakeLists.txt
+++ b/fprime-baremetal/Os/Baremetal/CMakeLists.txt
@@ -2,25 +2,26 @@
 ## Shared Section
 # -----------------------------------------
 
-set(SOURCE_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/error.cpp"
+register_fprime_module(
+    Os_Baremetal_Shared
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/error.cpp"
+    HEADERS
+        "${CMAKE_CURRENT_LIST_DIR}/error.hpp"
+    DEPENDS
+        Fw_Types
 )
-set(HEADER_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/error.hpp"
-)
-set(MOD_DEPS Fw_Types)
-register_fprime_module(Os_Baremetal_Shared)
 
 # Setup MicroFs
-set(SOURCE_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/MicroFs/MicroFs.cpp"
+register_fprime_module(
+    Os_Baremetal_MicroFs
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/MicroFs/MicroFs.cpp"
+    HEADERS
+        "${CMAKE_CURRENT_LIST_DIR}/MicroFs/MicroFs.hpp"
+    DEPENDS
+        Fw_Types
 )
-set(HEADER_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/MicroFs/MicroFs.hpp"
-)
-set(MOD_DEPS Fw_Types)
-
-register_fprime_module(Os_Baremetal_MicroFs)
 
 add_library(fprime-baremetal_Os_Baremetal INTERFACE)
 
@@ -33,23 +34,35 @@ add_fprime_supplied_os_module(Task Baremetal fprime-baremetal_Os_TaskRunner)
 # MicroFs Full Test Section
 # -----------------------------------------
 
-set(UT_SOURCE_FILES
-    "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/MicroFsTest.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/Tester.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/MyRules.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/SimFileSystem.cpp"
+register_fprime_ut(
+    MicroFsFullTest
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/MicroFsTest.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/Tester.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/MyRules.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/SimFileSystem.cpp"
+    DEPENDS
+       Os
+       STest
+    CHOOSES_IMPLEMENTATIONS
+        Os_File_Baremetal_MicroFs
 )
-
-add_fprime_os_test(MicroFsFullTest "${UT_SOURCE_FILES}" "Os/File\;Os/File/Baremetal/MicroFs")
 
 # -----------------------------------------
 # MicroFs File Test Section
 # -----------------------------------------
 
-set(UT_SOURCE_FILES
-    "${FPRIME_FRAMEWORK_PATH}/Os/test/ut/file/CommonTests.cpp"
-    "${FPRIME_FRAMEWORK_PATH}/Os/test/ut/file/FileRules.cpp"
-    "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/MicroFsFileTests.cpp"
-)
 
-add_fprime_os_test(MicroFsFileTest "${UT_SOURCE_FILES}" "Os/File\;Os/File/Baremetal/MicroFs" Os_Test_File_SyntheticFileSystem)
+register_fprime_ut(
+    MicroFsFileTest
+    SOURCES
+        "${FPRIME_FRAMEWORK_PATH}/Os/test/ut/file/CommonTests.cpp"
+        "${FPRIME_FRAMEWORK_PATH}/Os/test/ut/file/FileRules.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/MicroFsFileTests.cpp"
+    DEPENDS
+        Os
+        STest
+        Os_Test_File_SyntheticFileSystem
+    CHOOSES_IMPLEMENTATIONS
+        Os_File_Baremetal_MicroFs
+)


### PR DESCRIPTION
Recent changes to the fprime cmake API causes builds to fail because of the definition of SOURCE_FILES and arguments being passed internally (`add_fprime_supplied_os_module` uses the new API) when both cannot be used at once. This updates `CMakeLists.txt` to completely use the new API.