### PR TITLE
Boost history size in TlmLinearChan UTs

### DIFF
--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
@@ -8,7 +8,7 @@
 #include <Fw/Test/UnitTest.hpp>
 
 #define INSTANCE 0
-#define MAX_HISTORY_SIZE 10
+#define MAX_HISTORY_SIZE 20
 #define QUEUE_DEPTH 10
 
 static const FwSizeType TEST_CHAN_SIZE = sizeof(FwChanIdType) + Fw::Time::SERIALIZED_SIZE + sizeof(U32);


### PR DESCRIPTION
A max history size of '10' does not work when a project is configured with small values for FW_COM_BUFFER_MAX_SIZE.