### PR TITLE
Fixes for compatibility with newer F Prime and stricter compiler flags

### DIFF
--- a/fprime-baremetal/Os/Baremetal/Directory.cpp
+++ b/fprime-baremetal/Os/Baremetal/Directory.cpp
@@ -64,13 +64,13 @@ BaremetalDirectory::Status BaremetalDirectory::read(char* fileNameBuffer, FwSize
 
     MicroFs& microfs = MicroFs::getSingleton();
 
-    if (this->m_handle.m_file_index >= microfs.s_microFsConfig.bins[this->m_handle.m_dir_index].numFiles) {
+    if (this->m_handle.m_file_index < 0 || FwSizeType(this->m_handle.m_file_index) >= microfs.s_microFsConfig.bins[this->m_handle.m_dir_index].numFiles) {
         return NO_MORE_FILES;
     }
 
     Status status = NO_MORE_FILES;
 
-    for (; this->m_handle.m_file_index < microfs.s_microFsConfig.bins[this->m_handle.m_dir_index].numFiles;
+    for (; FwSizeType(this->m_handle.m_file_index) < microfs.s_microFsConfig.bins[this->m_handle.m_dir_index].numFiles;
          this->m_handle.m_file_index++) {
         Fw::String fileStr;
         const char* filePathSpec = "/" MICROFS_BIN_STRING "%d/" MICROFS_FILE_STRING "%d";

--- a/fprime-baremetal/Os/Baremetal/FileSystem.cpp
+++ b/fprime-baremetal/Os/Baremetal/FileSystem.cpp
@@ -94,7 +94,7 @@ BaremetalFileSystem::Status BaremetalFileSystem::_getFreeSpace(const char* path,
     // iterate through bins
     for (FwIndexType currBin = 0; currBin < microfs.s_microFsConfig.numBins; currBin++) {
         // iterate through files in each bin
-        for (FwIndexType currFile = 0; currFile < microfs.s_microFsConfig.bins[currBin].numFiles; currFile++) {
+        for (FwSizeType currFile = 0; currFile < microfs.s_microFsConfig.bins[currBin].numFiles; currFile++) {
             totalBytes += statePtr->dataSize;
             // only add unused file slots to free space
             if (!statePtr->created) {

--- a/fprime-baremetal/Os/Baremetal/FileSystem.cpp
+++ b/fprime-baremetal/Os/Baremetal/FileSystem.cpp
@@ -35,6 +35,10 @@ BaremetalFileSystem::Status BaremetalFileSystem::_removeDirectory(const char* pa
     }
 }
 
+BaremetalFileSystem::Status BaremetalFileSystem::_getPathType(const char* path, PathType& pathType) {
+    return NOT_SUPPORTED;
+}
+
 BaremetalFileSystem::Status BaremetalFileSystem::_removeFile(const char* path) {
     if (path == nullptr) {
         return INVALID_PATH;

--- a/fprime-baremetal/Os/Baremetal/FileSystem.hpp
+++ b/fprime-baremetal/Os/Baremetal/FileSystem.hpp
@@ -68,6 +68,8 @@ class BaremetalFileSystem : public FileSystemInterface {
     //! \return Status of the operation
     Status _getFreeSpace(const char* path, FwSizeType& totalBytes, FwSizeType& freeBytes) override;
 
+    BaremetalFileSystem::Status _getPathType(const char* path, PathType& pathType) override;
+
     //! \brief Get the current working directory
     //!
     //! Writes the current working directory path to the provided buffer of size bufferSize.

--- a/fprime-baremetal/Os/Baremetal/MicroFs/MicroFs.cpp
+++ b/fprime-baremetal/Os/Baremetal/MicroFs/MicroFs.cpp
@@ -130,7 +130,7 @@ MicroFs::Status MicroFs::getFileStateIndex(const char* fileName, FwIndexType& st
         return MicroFs::Status::INVALID;
     }
 
-    if (fileIndex >= microfs.s_microFsConfig.bins[binIndex].numFiles) {
+    if (fileIndex < 0 || FwSizeType(fileIndex) >= microfs.s_microFsConfig.bins[binIndex].numFiles) {
         return MicroFs::Status::INVALID;
     }
 

--- a/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MicroFsFileTests.cpp
+++ b/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MicroFsFileTests.cpp
@@ -15,7 +15,7 @@
 #include "STest/Pick/Pick.hpp"
 namespace Os {
 namespace Test {
-namespace File {
+namespace FileTest {
 
 std::vector<std::shared_ptr<const std::string> > FILES;
 
@@ -102,7 +102,7 @@ void tearDown() {
     cleanup(0);
 }
 
-class MicroFsTester : public Tester {
+class MicroFsTester : public Os::Test::FileTest::Tester {
     //! Check if the test file exists.
     //! \return true if it exists, false otherwise.
     //!
@@ -131,11 +131,11 @@ class MicroFsTester : public Tester {
     bool functional() const override { return true; }
 };
 
-std::unique_ptr<Os::Test::File::Tester> get_tester_implementation() {
-    return std::unique_ptr<Os::Test::File::Tester>(new Os::Test::File::MicroFsTester());
+std::unique_ptr<Os::Test::FileTest::Tester> get_tester_implementation() {
+    return std::unique_ptr<Os::Test::FileTest::Tester>(new Os::Test::FileTest::MicroFsTester());
 }
 
-}  // namespace File
+}  // namespace FileTest
 }  // namespace Test
 }  // namespace Os
 

--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/Tester.cpp
@@ -176,7 +176,7 @@ void Tester::checkBuff(FwChanIdType chanNum, FwChanIdType totalChan, FwChanIdTyp
         FwPacketDescriptorType desc;
         stat = this->m_rcvdBuffer[packet].deserialize(desc);
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
-        ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacket::FW_PACKET_TELEM));
+        ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_TELEM));
 
         for (FwChanIdType chan = 0; chan < CHANS_PER_COMBUFFER; chan++) {
             // decode channel ID


### PR DESCRIPTION
1. FW_PACKET_TELEM was broken by the CCSDS support added to fprime, which involved changing how ComPacketType is defined.
2. The MicroFs implementation appears to have been compiled without -Wsign-compare and without -Wvla, so a few comparisons need to be updated
3. _getPathType needs to be implemented to avoid a compilation failure
4. Fix unit tests for changes in upstream F Prime.