### PR TITLE
Fix build errors with latest F Prime commit

### DIFF
--- a/fprime-baremetal/Os/Baremetal/CMakeLists.txt
+++ b/fprime-baremetal/Os/Baremetal/CMakeLists.txt
@@ -68,6 +68,7 @@ register_fprime_ut(
         "${CMAKE_CURRENT_LIST_DIR}/MicroFs/test/ut/MicroFsFileTests.cpp"
     DEPENDS
         Os
+        Os_RawTime
         STest
         Os_Test_File_SyntheticFileSystem
     CHOOSES_IMPLEMENTATIONS

--- a/fprime-baremetal/config/CMakeLists.txt
+++ b/fprime-baremetal/config/CMakeLists.txt
@@ -3,4 +3,5 @@ register_fprime_config(
     HEADERS
         "${CMAKE_CURRENT_LIST_DIR}/MicroFsCfg.hpp"
     INTERFACE # No buildable files generated
+    BASE_CONFIG
 )


### PR DESCRIPTION
This brings us up to date with upstream commit 2e7bdd50ac5e94160004151127d28b53c1da81da.