### PR TITLE
Fix random failure in FunctionalIO.RandomizedTesting

### DIFF
--- a/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MicroFsFileTests.cpp
+++ b/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MicroFsFileTests.cpp
@@ -21,7 +21,10 @@ std::vector<std::shared_ptr<const std::string> > FILES;
 
 Fw::MallocAllocator alloc;
 
-static const U32 MAX_FILES = 100;
+// Match this number to RANDOM_BOUND in CommonTests.cpp.
+// If it does not match, a unit test may hit a corner case
+// where it opens more files than MicroFs is configured to allow.
+static const U32 MAX_FILES = 1000;
 static constexpr U16 MAX_FILE_PATH = 256;
 static const char BASE_PATH[] = "/" MICROFS_BIN_STRING "0";
 static const char TEST_FILE[] = MICROFS_FILE_STRING;


### PR DESCRIPTION
FunctionalIO.RandomizedTesting may open more files than MicroFs' unit test is configured to allow. This leads to random failures. I've configured MicroFs, in the unit tests, to allow this much https://github.com/nasa/fprime/blob/devel/Os/test/ut/file/CommonTests.cpp#L9.


Addresses issue https://github.com/fprime-community/fprime-baremetal/issues/18


cc: @celskeggs 