### PR TITLE
Added OverrideNewDelete

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ baremetal-size {build}
 ```
 
 Change `{build}` to your specific build (i.e. `teensy41`, `featherM0`, etc.)
+
+## Tracking memory allocation done by new & delete
+fprime-baremental includes a feature which overrides the default implementations of new, new[], delete, and delete[] with calls to a Fw::MallocAllocator class. 
+There are also helper functions for registering a Fw::MallocAllocator and for setting the default memoryId to be used when allocating memory. 
+This feature is disabled by default, it can be enabled by setting FPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE in your project's top level CMakeLists.txt.
+One example of how to leverage this feature is the StrictMallocAllocator class in fprime-vorago

--- a/fprime-baremetal/Os/CMakeLists.txt
+++ b/fprime-baremetal/Os/CMakeLists.txt
@@ -1,2 +1,5 @@
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Baremetal")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/TaskRunner")
+if(FPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE)
+    add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/OverrideNewDelete")
+endif()

--- a/fprime-baremetal/Os/OverrideNewDelete/CMakeLists.txt
+++ b/fprime-baremetal/Os/OverrideNewDelete/CMakeLists.txt
@@ -1,0 +1,16 @@
+####
+# F prime CMakeLists.txt:
+#
+# SOURCE_FILES: combined list of source and autocoding files
+# MOD_DEPS: (optional) module dependencies
+#
+####
+register_fprime_module(
+    Os_Baremetal_OverrideNewDelete
+    SOURCES
+        "${CMAKE_CURRENT_LIST_DIR}/OverrideNewDelete.cpp"
+    HEADERS
+        "${CMAKE_CURRENT_LIST_DIR}/OverrideNewDelete.hpp"
+    DEPENDS
+        Fw_Types
+)

--- a/fprime-baremetal/Os/OverrideNewDelete/OverrideNewDelete.cpp
+++ b/fprime-baremetal/Os/OverrideNewDelete/OverrideNewDelete.cpp
@@ -1,0 +1,152 @@
+// ======================================================================
+// \title fprime-baremetal/Os/Baremetal/OverrideNewDelete.cpp
+// \brief Implementation for new/delete overrides
+// =====================================================================
+#include "OverrideNewDelete.hpp"
+#include <malloc.h>
+#include <stdio.h>
+#include <Fw/Types/Assert.hpp>
+#include <atomic>
+#include <new>  // included to get std::nothrow_t
+
+namespace Os {
+namespace Baremetal {
+namespace OverrideNewDelete {
+
+// global variables
+//! Modifiable default (useful before calling code with new/delete to attribute the memory user)
+FwEnumStoreType customId = DEFAULT_ID;
+//! Pointer to MemAllocator
+static Fw::MemAllocator* pAllocator = nullptr;
+
+// Prototypes
+void deallocateMemoryWoId(void* ptr);
+void deallocateMemory(const FwEnumStoreType identifier, void* ptr);
+void* allocateMemoryWoId(const FwSizeType size);
+void* allocateMemory(const FwEnumStoreType identifier, const FwSizeType size);
+
+// Function implementations
+void setDefaultId(FwEnumStoreType tmpId) {
+    customId = tmpId;
+}
+FwSizeType registerMemAllocator(Fw::MemAllocator* allocator) {
+    FW_ASSERT(pAllocator == nullptr);
+    FW_ASSERT(allocator != nullptr);
+    pAllocator = allocator;
+    // Get & return number of bytes already allocated
+    struct mallinfo mi = mallinfo();
+    return mi.uordblks;
+}
+
+void deallocateMemoryWoId(void* ptr) {
+    deallocateMemory(customId, ptr);
+}
+
+void deallocateMemory(const FwEnumStoreType identifier, void* ptr) {
+    FW_ASSERT(pAllocator != nullptr);
+    if (pAllocator == nullptr) {
+        ::free(ptr);
+    } else {
+        pAllocator->deallocate(identifier, ptr);
+    }
+}
+
+void* allocateMemoryWoId(const FwSizeType size) {
+    return allocateMemory(customId, size);
+}
+
+void* allocateMemory(const FwEnumStoreType identifier, const FwSizeType size) {
+    void* ptr;
+    if (pAllocator == nullptr) {
+        ptr = ::malloc(size);
+    } else {
+        FwSizeType cSize = size;
+        bool recoverable = false;
+        ptr = pAllocator->allocate(identifier, cSize, recoverable);
+        if (cSize != size) {
+            ptr = nullptr;
+        }
+    }
+    return ptr;
+}
+
+}  // namespace OverrideNewDelete
+}  // namespace Baremetal
+}  // namespace Os
+
+void* operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+    return Os::Baremetal::OverrideNewDelete::allocateMemoryWoId(size);
+}
+void* operator new(std::size_t size, const std::nothrow_t& tag) noexcept {
+    return Os::Baremetal::OverrideNewDelete::allocateMemoryWoId(size);
+}
+// Global operator new
+void* operator new(std::size_t size) {
+    return Os::Baremetal::OverrideNewDelete::allocateMemoryWoId(size);
+}
+// Global operator new w/ identifier
+void* operator new(std::size_t size, const FwEnumStoreType identifier) {
+    return Os::Baremetal::OverrideNewDelete::allocateMemory(identifier, size);
+}
+// Global override for operator new[]
+void* operator new[](std::size_t size) {
+    return Os::Baremetal::OverrideNewDelete::allocateMemoryWoId(size);
+}
+
+// Global override for operator new[] w/ identifier
+void* operator new[](std::size_t size, const FwEnumStoreType identifier) {
+    return Os::Baremetal::OverrideNewDelete::allocateMemory(identifier, size);
+}
+
+// Global operator delete
+void operator delete(void* ptr) noexcept {
+    Os::Baremetal::OverrideNewDelete::deallocateMemoryWoId(ptr);
+}
+
+// Global operator delete w/ identifier
+void operator delete(void* ptr, const FwEnumStoreType identifier) noexcept {
+    Os::Baremetal::OverrideNewDelete::deallocateMemory(identifier, ptr);
+}
+
+// Global operator delete[]
+void operator delete[](void* ptr) noexcept {
+    Os::Baremetal::OverrideNewDelete::deallocateMemoryWoId(ptr);
+}
+
+// Global operator delete[] w/ identifier
+void operator delete[](void* ptr, const FwEnumStoreType identifier) noexcept {
+    Os::Baremetal::OverrideNewDelete::deallocateMemory(identifier, ptr);
+}
+
+// If you need to deep dive into all memory calls being done,  add
+// 'list(APPEND ARGN "-Wl,--wrap=malloc" "-Wl,--wrap=free"  "-Wl,--wrap=calloc" "-Wl,--wrap=realloc")'
+// to fprime__internal_target_interceptor
+extern "C" {
+// Declare the original malloc function (aliased as __real_malloc)
+void* __real_malloc(size_t size);
+
+// Your wrapper function for malloc
+void* __wrap_malloc(size_t size) {
+    printf("malloc %d\n", size);
+    return __real_malloc(size);
+}
+// Declare the original free function (aliased as __real_free)
+void __real_free(void* ptr);
+
+// wrapper function for free
+void __wrap_free(void* ptr) {
+    printf("free %p\n", ptr);
+    return __real_free(ptr);
+}
+void* __real_calloc(size_t num, size_t size);  // Declare the real calloc
+void* __wrap_calloc(size_t num, size_t size) {
+    printf("calloc %d, %d\n", num, size);
+    return __real_calloc(num, size);  // Call the real calloc
+}
+void* __real_realloc(void* ptr, size_t size);
+
+void* __wrap_realloc(void* ptr, size_t size) {
+    printf("realloc %p, %d\n", ptr, size);
+    return __real_realloc(ptr, size);
+}
+}

--- a/fprime-baremetal/Os/OverrideNewDelete/OverrideNewDelete.hpp
+++ b/fprime-baremetal/Os/OverrideNewDelete/OverrideNewDelete.hpp
@@ -1,0 +1,51 @@
+// ======================================================================
+// \title fprime-baremetal/Os/Baremetal/OverrideNewDelete.hpp
+// \brief Header file for overriding new & delete operators with custom implementations
+// that use a MemAllocator
+// ======================================================================
+#ifndef OS_Baremetal_OverrideNewDelete_HPP
+#define OS_Baremetal_OverrideNewDelete_HPP
+#include <stdio.h>
+#include <Fw/Types/MallocAllocator.hpp>
+
+//! delete operator that supports an identifier argument
+void operator delete[](void* ptr, const FwEnumStoreType identifier) noexcept;
+//! delete[] operator that supports an identifier argument
+void operator delete(void* ptr, const FwEnumStoreType identifier) noexcept;
+//! new operator that supports an identifier argument
+void* operator new[](std::size_t size, const FwEnumStoreType identifier);
+//! new[] operator that supports an identifier argument
+void* operator new(std::size_t size, const FwEnumStoreType identifier);
+
+namespace Os {
+namespace Baremetal {
+namespace OverrideNewDelete {
+
+//! ID passed to Fw::MemAllocator::allocate() and Fw::MemAllocator::deallocate() calls
+constexpr FwEnumStoreType DEFAULT_ID = -1;
+
+//! \brief Register a memory allocator for all future new operator calls
+//!
+//! \param allocator MemAllocator to use for all future new/delete calls
+//! \return Returns number of bytes allocated before
+FwSizeType registerMemAllocator(Fw::MemAllocator* allocator);
+
+void setDefaultId(FwEnumStoreType tmpId);
+// Temporary change default ID
+class TemporaryDefaultId {
+  public:
+    TemporaryDefaultId(FwEnumStoreType tmpId) {
+        puts("set default ID");
+        setDefaultId(tmpId);
+    }
+
+    ~TemporaryDefaultId() {
+        puts("restore default ID");
+        setDefaultId(DEFAULT_ID);
+    }
+};
+
+}  // namespace OverrideNewDelete
+}  // namespace Baremetal
+}  // namespace Os
+#endif  // OS_Baremetal_OverrideNewDelete_HPP

--- a/fprime-baremetal/Svc/TlmLinearChan/CMakeLists.txt
+++ b/fprime-baremetal/Svc/TlmLinearChan/CMakeLists.txt
@@ -10,6 +10,11 @@ set(SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/TlmLinearChan.fpp"
   "${CMAKE_CURRENT_LIST_DIR}/TlmLinearChan.cpp"
 )
+if(FPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE)
+set(MOD_DEPS
+        Os_OverrideNewDelete
+)
+endif()
 
 register_fprime_module()
 

--- a/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.cpp
@@ -8,12 +8,14 @@
 #include <Fw/Types/Assert.hpp>
 #include <config/FpConfig.hpp>
 #include <fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.hpp>
-
+#ifdef FPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE
+#include <fprime-baremetal/Os/OverrideNewDelete/OverrideNewDelete.hpp>
+#endif
 #include <new>
 
 namespace Baremetal {
 
-TlmLinearChan::TlmLinearChan(const char* name) : TlmLinearChanComponentBase(name), m_setupDone(false) {}
+TlmLinearChan::TlmLinearChan(const char* name) : TlmLinearChanComponentBase(name), m_memId(0), m_setupDone(false) {}
 
 TlmLinearChan::~TlmLinearChan() {
     if (this->m_tlmEntries != nullptr) {
@@ -31,6 +33,12 @@ TlmLinearChan::~TlmLinearChan() {
 void TlmLinearChan::init(FwSizeType queueDepth,   /*!< The queue depth*/
                          FwEnumStoreType instance /*!< The instance number*/
 ) {
+#ifdef FPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE
+    // This component's init does dynamic allocation (through Os::Queue)
+    // So set the default memory ID
+    Os::Baremetal::OverrideNewDelete::TemporaryDefaultId tmp =
+        Os::Baremetal::OverrideNewDelete::TemporaryDefaultId(this->m_memId);
+#endif
     TlmLinearChanComponentBase::init(queueDepth, instance);
 }
 

--- a/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.hpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/TlmLinearChan.hpp
@@ -23,6 +23,7 @@ class TlmLinearChan : public TlmLinearChanComponentBase {
     void init(FwSizeType queueDepth,   /*!< The queue depth*/
               FwEnumStoreType instance /*!< The instance number*/
     );
+    // NOTE: setup() should be called before init()
     void setup(FwEnumStoreType memId,       //!< Memory segment identifier
                Fw::MemAllocator& allocator  //!< Memory allocator
     );

--- a/library.cmake
+++ b/library.cmake
@@ -1,3 +1,6 @@
+if(FPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE)
+    add_definitions(-DFPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE)
+endif()
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-baremetal/config")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-baremetal/Os")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/fprime-baremetal/Svc")


### PR DESCRIPTION
Added a feature which overrides the default implementations of new, new[], delete, and delete[] with calls to a Fw::MallocAllocator class. This feature is disabled by default, it can be enabled by setting FPRIME_BAREMENTAL_OVERRIDE_NEW_DELETE in a project's top level CMakeLists.txt