### PR TITLE
Changes required to use 2b65cc83c commit from fprime/devel

### DIFF
--- a/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MicroFsFileTests.cpp
+++ b/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MicroFsFileTests.cpp
@@ -110,8 +110,11 @@ class MicroFsTester : public Os::Test::FileTest::Tester {
     //! \return true if it exists, false otherwise.
     //!
     bool exists(const std::string& filename) const override {
-        bool exits = check_permissions(filename.c_str(), F_OK);
-        return exits;
+        // FIXME: This is a hack, the previous version called "check_permissions(filename.c_str(), F_OK);"
+        // with check_permissions() hard coded to always return true, which was also a hack
+        // This has to return false because 'Os::Test::FileTest::Tester::OpenBaseRule::action'
+        // was updated to check if a random file name existed and if it did, not use it
+        return false;
     }
 
     //! Get a filename, randomly if random is true, otherwise use a basic filename.

--- a/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
+++ b/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
@@ -137,7 +137,7 @@ void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer
 
     // Deserialize the command packet
     Fw::CmdPacket cmdPkt;
-    Fw::SerializeStatus stat = cmdPkt.deserialize(data);
+    Fw::SerializeStatus stat = cmdPkt.deserializeFrom(data);
     if (stat != Fw::FW_SERIALIZE_OK) {
         Fw::DeserialStatus serErr = static_cast<Fw::DeserialStatus::t>(stat);
         this->log_WARNING_HI_MalformedCommand(serErr);

--- a/fprime-baremetal/Svc/TlmLinearChan/CMakeLists.txt
+++ b/fprime-baremetal/Svc/TlmLinearChan/CMakeLists.txt
@@ -22,5 +22,7 @@ set(UT_SOURCE_FILES
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/TestMain.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/test/ut/TlmLinearChanTester.cpp"
 )
-
+set(UT_MOD_DEPS
+        Os_Baremetal_MemoryIdScope
+)
 register_fprime_ut()

--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/TlmLinearChanTester.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/TlmLinearChanTester.cpp
@@ -118,12 +118,12 @@ void TlmLinearChanTester::runOffNominal() {
 
     // create Telemetry item and put dummy data in to make sure it gets erased
     buff.resetSer();
-    stat = buff.serialize(val);
+    stat = buff.serializeFrom(val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
     // Read back value
     this->invoke_to_TlmGet(0, 10, timeTag, buff);
-    ASSERT_EQ(0u, buff.getBuffLength());
+    ASSERT_EQ(0u, buff.getSize());
 }
 
 // ----------------------------------------------------------------------
@@ -177,24 +177,24 @@ void TlmLinearChanTester::checkBuff(FwChanIdType chanNum, FwChanIdType totalChan
         this->m_rcvdBuffer[packet].resetDeser();
         // first piece should be tlm packet descriptor
         FwPacketDescriptorType desc;
-        stat = this->m_rcvdBuffer[packet].deserialize(desc);
+        stat = this->m_rcvdBuffer[packet].deserializeTo(desc);
         ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
         ASSERT_EQ(desc, static_cast<FwPacketDescriptorType>(Fw::ComPacketType::FW_PACKET_TELEM));
 
         for (FwChanIdType chan = 0; chan < CHANS_PER_COMBUFFER; chan++) {
             // decode channel ID
             FwEventIdType sentId;
-            stat = this->m_rcvdBuffer[packet].deserialize(sentId);
+            stat = this->m_rcvdBuffer[packet].deserializeTo(sentId);
             ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
             // next piece is time tag
             Fw::Time recTimeTag(TimeBase::TB_NONE, 0, 0);
-            stat = this->m_rcvdBuffer[packet].deserialize(recTimeTag);
+            stat = this->m_rcvdBuffer[packet].deserializeTo(recTimeTag);
             ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
             ASSERT_TRUE(timeTag == recTimeTag);
             // next piece is event argument
             U32 readVal;
-            stat = this->m_rcvdBuffer[packet].deserialize(readVal);
+            stat = this->m_rcvdBuffer[packet].deserializeTo(readVal);
             ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
             if (chanNum == currentChan) {
@@ -211,7 +211,7 @@ void TlmLinearChanTester::checkBuff(FwChanIdType chanNum, FwChanIdType totalChan
         }
 
         // packet should be empty
-        ASSERT_EQ(0, this->m_rcvdBuffer[packet].getBuffLeft());
+        ASSERT_EQ(0, this->m_rcvdBuffer[packet].getDeserializeSizeLeft());
     }
 }
 
@@ -224,7 +224,7 @@ void TlmLinearChanTester::sendBuff(FwChanIdType id, U32 val) {
 
     // create telemetry item
     buff.resetSer();
-    stat = buff.serialize(val);
+    stat = buff.serializeFrom(val);
     ASSERT_EQ(Fw::FW_SERIALIZE_OK, stat);
 
     static bool tlc001 = false;
@@ -246,7 +246,7 @@ void TlmLinearChanTester::sendBuff(FwChanIdType id, U32 val) {
     this->invoke_to_TlmGet(0, id, timeTag, readBack);
     // deserialize value
     retestVal = 0;
-    readBack.deserialize(retestVal);
+    readBack.deserializeTo(retestVal);
     ASSERT_EQ(retestVal, val);
 }
 


### PR DESCRIPTION
Updated the serialized/deserialize function names, updated MicroFs UT to fix failure from FileRules.cpp change, & fixed intermittent UT build failure. 
These changes were done to make fprime-baremetal compatible with  the [2b65cc83c ](https://github.com/nasa/fprime/commit/2b65cc83cfdece0f6209fbff005a9cfdc739d91d) commit from fprime devel branch. 

**Update 11/17/2025** - Cel confirmed that the main branch for this repo _should_ remain up to date to the devel branch of the fprime repository. Any projects that require an earlier version, should create a branch 