### PR TITLE
Added Os_RawTime as a dep of Os_Baremetal_Shared

### DIFF
--- a/fprime-baremetal/Os/Baremetal/CMakeLists.txt
+++ b/fprime-baremetal/Os/Baremetal/CMakeLists.txt
@@ -19,6 +19,7 @@ register_fprime_module(
         "${CMAKE_CURRENT_LIST_DIR}/error.hpp"
     DEPENDS
         Fw_Types
+        Os_RawTime
 )
 
 # Setup MicroFs


### PR DESCRIPTION
When using an updated fpp, I saw the below build failure after a purge/clean and then build. `Baremetal/error.cpp` relies on `Os/RawTime.hpp` and is included in the `Os_Baremetal_Shared`  module, so Os_RawTime should added to the depends list for `Os_Baremetal_Shared`
```
In file included from $PWDlib/fprime-baremetal/fprime-baremetal/Os/Baremetal/error.cpp:5:
In file included from $PWDlib/fprime-baremetal/fprime-baremetal/Os/Baremetal/error.hpp:10:
In file included from $PWDlib/fprime/Os/RawTime.hpp:9:
In file included from $PWDlib/fprime/Fw/Time/TimeInterval.hpp:5:
$PWDlib/fprime/Fw/Time/Time.hpp:5:10: fatal error: 'Fw/Time/TimeValueSerializableAc.hpp' file not found
    5 | #include <Fw/Time/TimeValueSerializableAc.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
