### PR TITLE
Add missing Os_Baremetal_Shared dependency

### DIFF
--- a/fprime-baremetal/Os/Baremetal/CMakeLists.txt
+++ b/fprime-baremetal/Os/Baremetal/CMakeLists.txt
@@ -19,6 +19,7 @@ register_fprime_module(
         "${CMAKE_CURRENT_LIST_DIR}/error.hpp"
     DEPENDS
         Fw_Types
+        Os_RawTime
 )
 
 # Setup MicroFs


### PR DESCRIPTION
`error.cpp` includes `Fw/Time/TimeValueSerializableAc.hpp` indirectly through `Os/RawTime.hpp` and `Fw/Time/TimeInterval.hpp`. Since `Os_Baremetal_Shared` did not previously depend on `Os_RawTime`, the FPP compiler was not guaranteed to generate `Fw/Time/TimeValueSerializableAc.hpp` before the preprocessor attempted to process `error.cpp`. This leads to a failure to build. This PR corrects this problem by adding the missing dependency between `Os_Baremetal_Shared` and `Os_RawTime`.