### PR TITLE
Add Fw.Cmd-typed input port for commands

### DIFF
--- a/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
+++ b/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.cpp
@@ -132,21 +132,11 @@ void PassiveCmdDispatcher::compCmdStat_handler(FwIndexType portNum,
     }
 }
 
-void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
+void PassiveCmdDispatcher::seqCmd_helper(FwIndexType portNum,
+                                         FwOpcodeType opcode,
+                                         U32 context,
+                                         Fw::CmdArgBuffer& args) {
     FW_ASSERT(this->m_cmdTables != nullptr);
-
-    // Deserialize the command packet
-    Fw::CmdPacket cmdPkt;
-    Fw::SerializeStatus stat = cmdPkt.deserializeFrom(data);
-    if (stat != Fw::FW_SERIALIZE_OK) {
-        Fw::DeserialStatus serErr = static_cast<Fw::DeserialStatus::t>(stat);
-        this->log_WARNING_HI_MalformedCommand(serErr);
-        if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
-            this->seqCmdStatus_out(portNum, cmdPkt.getOpCode(), context, Fw::CmdResponse::VALIDATION_ERROR);
-        }
-        return;
-    }
-    FwOpcodeType opcode = cmdPkt.getOpCode();
 
     // Search for the opcode in the dispatch table
     DispatchEntry* entry = nullptr;
@@ -184,7 +174,7 @@ void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer
         }
 
         // Pass arguments to the argument buffer and log the dispatched command
-        this->compCmdSend_out(entry->port, opcode, this->m_seq, cmdPkt.getArgBuffer());
+        this->compCmdSend_out(entry->port, opcode, this->m_seq, args);
         this->log_COMMAND_OpCodeDispatched(opcode, entry->port);
     } else {
         // Opcode could not be found in the dispatch table, fail the command
@@ -196,6 +186,28 @@ void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer
 
     // Increment sequence number
     this->m_seq++;
+}
+
+void PassiveCmdDispatcher::seqCmdBuff_handler(FwIndexType portNum, Fw::ComBuffer& data, U32 context) {
+    // Deserialize the command packet
+    Fw::CmdPacket cmdPkt;
+    Fw::SerializeStatus stat = cmdPkt.deserializeFrom(data);
+    if (stat != Fw::FW_SERIALIZE_OK) {
+        Fw::DeserialStatus serErr = static_cast<Fw::DeserialStatus::t>(stat);
+        this->log_WARNING_HI_MalformedCommand(serErr);
+        if (this->isConnected_seqCmdStatus_OutputPort(portNum)) {
+            this->seqCmdStatus_out(portNum, cmdPkt.getOpCode(), context, Fw::CmdResponse::VALIDATION_ERROR);
+        }
+        return;
+    }
+    seqCmd_helper(portNum, cmdPkt.getOpCode(), context, cmdPkt.getArgBuffer());
+}
+
+void PassiveCmdDispatcher::seqCmdIn_handler(FwIndexType portNum,
+                                            FwOpcodeType opCode,
+                                            U32 cmdSeq,
+                                            Fw::CmdArgBuffer& args) {
+    seqCmd_helper(portNum, opCode, cmdSeq, args);
 }
 
 // ----------------------------------------------------------------------

--- a/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
+++ b/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
@@ -85,6 +85,7 @@ module Baremetal {
 
         # Port matching specifiers
         match compCmdSend with compCmdReg
+        match seqCmdStatus with seqCmdBuff
 
         ###############################################################################
         # Standard AC Ports: Required for Channels, Events, Commands, and Parameters

--- a/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
+++ b/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
@@ -77,6 +77,9 @@ module Baremetal {
         @ Command buffer input port for sequencers or other sources of command buffers
         sync input port seqCmdBuff: [CmdDispatcherSequencePorts] Fw.Com
 
+        @ Command input port for sequencers or other sources of commands
+        sync input port seqCmdIn: [CmdDispatcherSequencePorts] Fw.Cmd
+
         @ Output command sequence status ports
         output port seqCmdStatus: [CmdDispatcherSequencePorts] Fw.CmdResponse
 

--- a/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
+++ b/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.fpp
@@ -85,7 +85,6 @@ module Baremetal {
 
         # Port matching specifiers
         match compCmdSend with compCmdReg
-        match seqCmdStatus with seqCmdBuff
 
         ###############################################################################
         # Standard AC Ports: Required for Channels, Events, Commands, and Parameters

--- a/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp
+++ b/fprime-baremetal/Svc/PassiveCmdDispatcher/PassiveCmdDispatcher.hpp
@@ -63,6 +63,12 @@ class PassiveCmdDispatcher final : public PassiveCmdDispatcherComponentBase {
 
   private:
     // ----------------------------------------------------------------------
+    // Helper functions for input ports
+    // ----------------------------------------------------------------------
+
+    void seqCmd_helper(FwIndexType portNum, FwOpcodeType opCode, U32 cmdSeq, Fw::CmdArgBuffer& args);
+
+    // ----------------------------------------------------------------------
     // Handler implementations for typed input ports
     // ----------------------------------------------------------------------
 
@@ -89,6 +95,15 @@ class PassiveCmdDispatcher final : public PassiveCmdDispatcherComponentBase {
                             Fw::ComBuffer& data,  //!< Buffer containing packet data
                             U32 context           //!< Call context value; meaning chosen by user
                             ) override;
+
+    //! Handler implementation for seqCmdBuffFwCmd
+    //!
+    //! Command buffer input port for sequencers or other sources of command buffers (for Fw.Cmd input)
+    void seqCmdIn_handler(FwIndexType portNum,    //!< The port number
+                          FwOpcodeType opCode,    //!< Command Op Code
+                          U32 cmdSeq,             //!< Command Sequence
+                          Fw::CmdArgBuffer& args  //!< Command arguments
+                          ) override;
 
   private:
     // ----------------------------------------------------------------------

--- a/fprime-baremetal/Svc/PassiveCmdDispatcher/docs/sdd.md
+++ b/fprime-baremetal/Svc/PassiveCmdDispatcher/docs/sdd.md
@@ -28,6 +28,7 @@ Add a class diagram here
 | [`Fw::Cmd`](../../../Fw/Cmd/docs/sdd.md) | `compCmdSend` | `output` | Send commands to components |
 | [`Fw::CmdResponse`](../../../Fw/Cmd/docs/sdd.md) | `compCmdStat` | `sync input` | Port for components to report command status |
 | [`Fw::Com`](../../../Fw/Com/docs/sdd.md) | `seqCmdBuff` | `sync input` | Receive command buffer |
+| [`Fw::Cmd`](../../../Fw/Com/docs/sdd.md) | `seqCmdIn` | `sync input` | Receive command in command format |
 | [`Fw::CmdResponse`](../../../Fw/Cmd/docs/sdd.md) | `seqCmdStatus` | `output` | Send command status to command buffer source |
 
 ## Component States


### PR DESCRIPTION
Added a new input port for incoming commands using the type `Fw.Cmd` to work alongside the existing `Fw.Com` typed input port.  Both input port handlers share the same helper function.  This work parallels the F-prime ticket [4640](https://github.com/nasa/fprime/issues/4640) where `CommandDispatcher` will receive similar updates.