### PR TITLE
Fix memory leak failure in TlmLinearChan UTs

### DIFF
--- a/fprime-baremetal/Svc/TlmLinearChan/test/ut/TlmLinearChanTester.cpp
+++ b/fprime-baremetal/Svc/TlmLinearChan/test/ut/TlmLinearChanTester.cpp
@@ -30,7 +30,9 @@ TlmLinearChanTester ::TlmLinearChanTester()
     this->connectPorts();
 }
 
-TlmLinearChanTester ::~TlmLinearChanTester() {}
+TlmLinearChanTester ::~TlmLinearChanTester() {
+    this->component.deinit();
+}
 
 // ----------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
Without this fix, we get the following test failure with F Prime v4.2.1:

```
6: =================================================================
6: ==1499192==ERROR: LeakSanitizer: detected memory leaks
6: 
6: Direct leak of 2000 byte(s) in 16 object(s) allocated from:
6:     #0 0x7f8d9c911bb8 in __interceptor_malloc (/lib64/libasan.so.5+0xefbb8)
6:     #1 0x4d6a09 in Fw::MallocAllocator::allocate(int, unsigned long&, bool&, unsigned long) /[...]/lib/fprime/Fw/Types/MallocAllocator.cpp:24
6: 
6: SUMMARY: AddressSanitizer: 2000 byte(s) leaked in 16 allocation(s).
1/1 Test #6: fprime-baremetal_Svc_TlmLinearChan_ut_exe ...***Failed    0.06 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   1.62 sec

The following tests FAILED:
          6 - fprime-baremetal_Svc_TlmLinearChan_ut_exe (Failed)
Errors while running CTest
```
