### PR TITLE
Update MicroFs to sync to fprime commit 35d4c0e

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: Chromium
+IndentWidth: 4
+ColumnLimit: 120
+AccessModifierOffset: -2

--- a/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MyRules.cpp
+++ b/fprime-baremetal/Os/Baremetal/MicroFs/test/ut/MyRules.cpp
@@ -271,8 +271,9 @@ void Os::Tester::Listings::action(Os::Tester& state  //!< The test state
         auto stat = dir.open(dirname.toChar(), Os::DirectoryInterface::READ);
         ASSERT_EQ(stat, Os::DirectoryInterface::OP_OK);
         Fw::String filenameArray[MAX_FILES_PER_BIN];
+        Fw::ExternalArray<Fw::String> filenameExternalArray(filenameArray, MAX_FILES_PER_BIN);
         FwSizeType filenameCount = 0;
-        stat = dir.readDirectory(filenameArray, MAX_FILES_PER_BIN, filenameCount);
+        stat = dir.readDirectory(filenameExternalArray, filenameCount);
         ASSERT_EQ(filenameCount, MAX_FILES_PER_BIN);
         ASSERT_EQ(stat, Os::DirectoryInterface::OP_OK);
         for (U16 j = 0; j < MAX_FILES_PER_BIN; j++) {


### PR DESCRIPTION
Updated Os::Tester::Listings::action() for MyRules.cpp in the MicroFs unit test to be compatible with the fprime changes from PR 5488 (https://github.com/nasa/fprime/commit/35d4c0e881482adf372b8eee3eb56ad2dee74618) 